### PR TITLE
VK-Test-1: fix tableView behavior

### DIFF
--- a/Test/Screens/Reviews/ReviewsProvider.swift
+++ b/Test/Screens/Reviews/ReviewsProvider.swift
@@ -25,19 +25,27 @@ extension ReviewsProvider {
     }
 
     func getReviews(offset: Int = 0, completion: @escaping (GetReviewsResult) -> Void) {
+
         guard let url = bundle.url(forResource: "getReviews.response", withExtension: "json") else {
             return completion(.failure(.badURL))
         }
 
-        // Симулируем сетевой запрос - не менять
-        usleep(.random(in: 100_000...1_000_000))
+        DispatchQueue.global(qos: .userInitiated)
+            .async {
+                // Симулируем сетевой запрос - не менять
+                usleep(.random(in: 100_000...1_000_000))
 
-        do {
-            let data = try Data(contentsOf: url)
-            completion(.success(data))
-        } catch {
-            completion(.failure(.badData(error)))
-        }
+                do {
+                    let data = try Data(contentsOf: url)
+                    DispatchQueue.main.async {
+                        completion(.success(data))
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        completion(.failure(.badData(error)))
+                    }
+                }
+            }
     }
 
 }

--- a/Test/Screens/Reviews/ReviewsViewController.swift
+++ b/Test/Screens/Reviews/ReviewsViewController.swift
@@ -30,18 +30,28 @@ final class ReviewsViewController: UIViewController {
 // MARK: - Private
 
 private extension ReviewsViewController {
-
+    
     func makeReviewsView() -> ReviewsView {
         let reviewsView = ReviewsView()
         reviewsView.tableView.delegate = viewModel
         reviewsView.tableView.dataSource = viewModel
         return reviewsView
     }
-
+    
     func setupViewModel() {
-        viewModel.onStateChange = { [weak reviewsView] _ in
-            reviewsView?.tableView.reloadData() // PerformBatchUpdates
+        viewModel.onStateChange = { [weak self] state, change in
+            guard let self else { return }
+
+            let tableView = reviewsView.tableView
+            
+            switch change {
+            case .insertRows(let indexPaths):
+                tableView.performBatchUpdates {
+                    tableView.insertRows(at: indexPaths, with: .automatic)
+                }
+            case .reloadRow(let indexPath):
+                tableView.reloadRows(at: [indexPath], with: .automatic)
+            }
         }
     }
-
 }


### PR DESCRIPTION
В этом ПРе пофиксил лаги при скролле tableView:
1) Сделал "сетевой" запрос асинхронным 
2) Заменил reloadData на insertRows, чтобы постоянно не перезагружать всю таблицу. Если она будет большая, это приведет к проблемам. 